### PR TITLE
feat: display file name in task widget

### DIFF
--- a/src/components/filter_tab.rs
+++ b/src/components/filter_tab.rs
@@ -171,6 +171,7 @@ impl<'a> Component for FilterTab<'a> {
                 .iter()
                 .map(|t| VaultData::Task(t.clone()))
                 .collect::<Vec<VaultData>>(),
+            true,
         );
 
         Widget::render(tag_list, tag_area, frame.buffer_mut());

--- a/src/task_core/filter.rs
+++ b/src/task_core/filter.rs
@@ -11,7 +11,7 @@ pub fn parse_search_input(input: &str, config: &Config) -> (Task, bool) {
     let input_value = format!("{}{}", if has_state { "" } else { "- [ ]" }, input);
 
     // Parse the input
-    let search = match parse_task(&mut input_value.as_str(), config) {
+    let search = match parse_task(&mut input_value.as_str(), String::new(), config) {
         Ok(t) => t,
         Err(_e) => Task {
             name: String::from("Uncomplete search prompt"),

--- a/src/task_core/task.rs
+++ b/src/task_core/task.rs
@@ -82,6 +82,7 @@ pub struct Task {
     pub subtasks: Vec<Task>,
     pub description: Option<String>,
     pub due_date: DueDate,
+    pub filename: String,
     pub line_number: usize,
     pub name: String,
     pub priority: usize,
@@ -100,6 +101,7 @@ impl Default for Task {
             description: None,
             line_number: 1,
             subtasks: vec![],
+            filename: String::new(),
         }
     }
 }
@@ -223,7 +225,7 @@ mod tests {
             tags: Some(vec![String::from("tag1"), String::from("tag2")]),
             description: Some(String::from("This is a test task.")),
             line_number: 2,
-            subtasks: vec![],
+            ..Default::default()
         };
         let res = task.get_fixed_attributes(&config, 0);
         assert_eq!(res, "- [ ] Test Task 2021/12/03 p1 #tag1 #tag2");
@@ -240,7 +242,7 @@ mod tests {
             tags: Some(vec![String::from("tag3")]),
             description: None,
             line_number: 3,
-            subtasks: vec![],
+            ..Default::default()
         };
 
         let res = task.get_fixed_attributes(&config, 0);

--- a/src/task_core/vault_parser.rs
+++ b/src/task_core/vault_parser.rs
@@ -88,8 +88,9 @@ impl VaultParser {
     fn parse_file(&self, entry: &DirEntry) -> Option<VaultData> {
         debug!("Parsing {:?}", entry.file_name());
         let content = fs::read_to_string(entry.path()).unwrap_or_default();
-        let parser = ParserFileEntry {
+        let mut parser = ParserFileEntry {
             config: &self.config,
+            filename: String::new(),
         };
 
         parser.parse_file(entry.file_name().to_str().unwrap(), &content.as_str())

--- a/src/widgets/task_list.rs
+++ b/src/widgets/task_list.rs
@@ -14,14 +14,16 @@ pub struct TaskList {
     file_content: Vec<VaultData>,
     not_american_format: bool,
     state: ListState,
+    display_filename: bool,
 }
 
 impl TaskList {
-    pub fn new(config: &Config, file_content: &[VaultData]) -> Self {
+    pub fn new(config: &Config, file_content: &[VaultData], display_filename: bool) -> Self {
         Self {
             state: ListState::default(),
             not_american_format: !config.tasks_config.use_american_format,
             file_content: file_content.to_vec(),
+            display_filename,
         }
     }
 }
@@ -37,6 +39,7 @@ impl Widget for TaskList {
             let item = TaskListItem::new(
                 self.file_content[context.index].clone(),
                 self.not_american_format,
+                self.display_filename,
             );
             let height = item.height;
             (item, height.try_into().unwrap())

--- a/src/widgets/task_list_item.rs
+++ b/src/widgets/task_list_item.rs
@@ -13,14 +13,17 @@ pub struct TaskListItem {
     item: VaultData,
     pub height: usize,
     not_american_format: bool,
+    display_filename: bool,
 }
+
 impl TaskListItem {
-    pub fn new(item: VaultData, not_american_format: bool) -> Self {
+    pub fn new(item: VaultData, not_american_format: bool, display_filename: bool) -> Self {
         let height = Self::compute_height(&item);
         Self {
             item,
             height,
             not_american_format,
+            display_filename,
         }
     }
 
@@ -91,7 +94,7 @@ impl Widget for TaskListItem {
                 surrounding_block.render(area, buf);
 
                 for (i, child) in children.iter().enumerate() {
-                    let sb_widget = Self::new(child.clone(), self.not_american_format);
+                    let sb_widget = Self::new(child.clone(), self.not_american_format, false);
                     sb_widget.render(layout[i], buf);
                 }
             }
@@ -146,13 +149,21 @@ impl Widget for TaskListItem {
                 if lines.is_empty() && task.subtasks.is_empty() {
                     Paragraph::new(title).block(surrounding_block)
                 } else {
-                    Paragraph::new(Text::from(lines)).block(surrounding_block.title(title.clone()))
+                    Paragraph::new(Text::from(lines)).block(
+                        surrounding_block.title_top(title.clone()).title_bottom(
+                            if self.display_filename {
+                                Line::from(task.filename.clone()).right_aligned()
+                            } else {
+                                Line::from("")
+                            },
+                        ),
+                    )
                 }
                 .render(area, buf);
 
                 for (i, sb) in task.subtasks.iter().enumerate() {
                     let sb_widget =
-                        Self::new(VaultData::Task(sb.clone()), self.not_american_format);
+                        Self::new(VaultData::Task(sb.clone()), self.not_american_format, false);
                     sb_widget.render(layout[i + 1], buf);
                 }
             }


### PR DESCRIPTION
- If a file is selected, don't show filenames in preview
- If we're previewing the content of a header or subtasks, then show filenames