### PR TITLE
feat(tui): display container name in preview

### DIFF
--- a/src/components/explorer_tab.rs
+++ b/src/components/explorer_tab.rs
@@ -125,7 +125,7 @@ impl ExplorerTab<'_> {
 
         self.entries_right_view = match self
             .task_mgr
-            .get_vault_data_from_path_to_preview(&path_to_preview)
+            .get_vault_data_from_path_offset(&path_to_preview)
         {
             Ok(res) => res,
             Err(e) => vec![VaultData::Directory(e.to_string(), vec![])],
@@ -399,7 +399,7 @@ impl Component for ExplorerTab<'_> {
                     // We're already sure it exists since we entered the task editing mode
                     if let VaultData::Task(task) = self
                         .task_mgr
-                        .get_vault_data_from_path(&self.current_path)
+                        .get_vault_data_from_path_offset(&self.current_path)
                         .unwrap()[self.state_center_view.selected.unwrap_or_default()]
                     .clone()
                     {

--- a/src/components/explorer_tab.rs
+++ b/src/components/explorer_tab.rs
@@ -125,7 +125,7 @@ impl ExplorerTab<'_> {
 
         self.entries_right_view = match self
             .task_mgr
-            .get_vault_data_from_path(&path_to_preview, true)
+            .get_vault_data_from_path_to_preview(&path_to_preview)
         {
             Ok(res) => res,
             Err(e) => vec![VaultData::Directory(e.to_string(), vec![])],
@@ -399,7 +399,7 @@ impl Component for ExplorerTab<'_> {
                     // We're already sure it exists since we entered the task editing mode
                     if let VaultData::Task(task) = self
                         .task_mgr
-                        .get_vault_data_from_path(&self.current_path, false)
+                        .get_vault_data_from_path(&self.current_path)
                         .unwrap()[self.state_center_view.selected.unwrap_or_default()]
                     .clone()
                     {

--- a/src/components/explorer_tab.rs
+++ b/src/components/explorer_tab.rs
@@ -124,7 +124,7 @@ impl ExplorerTab<'_> {
         };
 
         self.entries_right_view = match self.task_mgr.get_vault_data_from_path(&path_to_preview) {
-            Ok(res) => res,
+            Ok(res) => vec![res],
             Err(e) => vec![VaultData::Directory(e.to_string(), vec![])],
         };
         self.task_list_widget_state.scroll_up();
@@ -396,9 +396,11 @@ impl Component for ExplorerTab<'_> {
                     // We're already sure it exists since we entered the task editing mode
                     if let VaultData::Task(task) = self
                         .task_mgr
-                        .get_vault_data_from_path(&self.current_path)
-                        .unwrap()[self.state_center_view.selected.unwrap_or_default()]
-                    .clone()
+                        .get_vault_data_from_path(
+                            &self.get_preview_path().unwrap_or(self.current_path.clone()),
+                        )
+                        .unwrap()
+                        .clone()
                     {
                         // Get input
                         let mut input = self.edit_task_bar.input.value();

--- a/src/components/explorer_tab.rs
+++ b/src/components/explorer_tab.rs
@@ -123,7 +123,9 @@ impl ExplorerTab<'_> {
             return;
         };
 
-        self.entries_right_view = match self.task_mgr.get_vault_data_from_path(&path_to_preview, 1)
+        self.entries_right_view = match self
+            .task_mgr
+            .get_vault_data_from_path(&path_to_preview, true)
         {
             Ok(res) => res,
             Err(e) => vec![VaultData::Directory(e.to_string(), vec![])],
@@ -397,7 +399,7 @@ impl Component for ExplorerTab<'_> {
                     // We're already sure it exists since we entered the task editing mode
                     if let VaultData::Task(task) = self
                         .task_mgr
-                        .get_vault_data_from_path(&self.current_path, 0)
+                        .get_vault_data_from_path(&self.current_path, false)
                         .unwrap()[self.state_center_view.selected.unwrap_or_default()]
                     .clone()
                     {

--- a/src/components/explorer_tab.rs
+++ b/src/components/explorer_tab.rs
@@ -74,21 +74,23 @@ impl ExplorerTab<'_> {
             // Vault root
             self.entries_left_view = vec![];
         } else {
-            self.entries_left_view = match self
-                .task_mgr
-                .get_path_layer_entries(&self.current_path[0..self.current_path.len() - 1])
-            {
+            self.entries_left_view = match self.task_mgr.get_explorer_entries_without_children(
+                &self.current_path[0..self.current_path.len() - 1],
+            ) {
                 Ok(res) => Self::vault_data_to_entry_list(&res),
                 Err(e) => vec![(String::from(WARNING_EMOJI), (e.to_string()))],
             };
         }
-        self.entries_center_view = match self.task_mgr.get_path_layer_entries(&self.current_path) {
+        self.entries_center_view = match self
+            .task_mgr
+            .get_explorer_entries_without_children(&self.current_path)
+        {
             Ok(res) => Self::vault_data_to_entry_list(&res),
             Err(_e) => {
                 // If no entries are found, go to parent object
                 while self
                     .task_mgr
-                    .get_path_layer_entries(&self.current_path)
+                    .get_explorer_entries_without_children(&self.current_path)
                     .is_err()
                     && !self.current_path.is_empty()
                 {
@@ -97,7 +99,7 @@ impl ExplorerTab<'_> {
                 Self::vault_data_to_entry_list(
                     &self
                         .task_mgr
-                        .get_path_layer_entries(&self.current_path)
+                        .get_explorer_entries_without_children(&self.current_path)
                         .unwrap_or_default(),
                 )
             }
@@ -254,7 +256,7 @@ impl ExplorerTab<'_> {
                 Self::apply_prefixes(&Self::vault_data_to_entry_list(
                     &self
                         .task_mgr
-                        .get_path_layer_entries(
+                        .get_explorer_entries_without_children(
                             &self
                                 .get_preview_path()
                                 .unwrap_or_else(|_| self.current_path.clone()),

--- a/src/components/explorer_tab.rs
+++ b/src/components/explorer_tab.rs
@@ -123,10 +123,7 @@ impl ExplorerTab<'_> {
             return;
         };
 
-        self.entries_right_view = match self
-            .task_mgr
-            .get_vault_data_from_path_offset(&path_to_preview)
-        {
+        self.entries_right_view = match self.task_mgr.get_vault_data_from_path(&path_to_preview) {
             Ok(res) => res,
             Err(e) => vec![VaultData::Directory(e.to_string(), vec![])],
         };
@@ -399,7 +396,7 @@ impl Component for ExplorerTab<'_> {
                     // We're already sure it exists since we entered the task editing mode
                     if let VaultData::Task(task) = self
                         .task_mgr
-                        .get_vault_data_from_path_offset(&self.current_path)
+                        .get_vault_data_from_path(&self.current_path)
                         .unwrap()[self.state_center_view.selected.unwrap_or_default()]
                     .clone()
                     {

--- a/src/components/explorer_tab/utils.rs
+++ b/src/components/explorer_tab/utils.rs
@@ -19,15 +19,15 @@ impl ExplorerTab<'_> {
 
     fn vault_data_to_prefix_name(vd: &VaultData) -> (String, String) {
         match vd {
-            VaultData::Directory(name, _) => (
+            VaultData::Directory(name, _) => (DIRECTORY_EMOJI.to_owned(), name.clone()),
+            VaultData::Header(level, name, _) => (
                 if name.contains(".md") {
                     FILE_EMOJI.to_owned()
                 } else {
-                    DIRECTORY_EMOJI.to_owned()
+                    "#".repeat(*level).clone()
                 },
                 name.clone(),
             ),
-            VaultData::Header(level, name, _) => ("#".repeat(*level).clone(), name.clone()),
             VaultData::Task(task) => (task.state.to_string(), task.name.clone()),
         }
     }

--- a/src/components/explorer_tab/utils.rs
+++ b/src/components/explorer_tab/utils.rs
@@ -113,7 +113,7 @@ impl ExplorerTab<'_> {
     pub(super) fn get_selected_task(&self) -> Option<Task> {
         let Ok(entries) = self
             .task_mgr
-            .get_vault_data_from_path(&self.current_path, 0)
+            .get_vault_data_from_path(&self.current_path, false)
         else {
             error!("Error while collecting tasks from path");
             return None;

--- a/src/components/explorer_tab/utils.rs
+++ b/src/components/explorer_tab/utils.rs
@@ -120,13 +120,8 @@ impl ExplorerTab<'_> {
         };
         debug!("Getting selected task from current path: {:?}", path);
 
-        let Ok(entries) = self.task_mgr.get_vault_data_from_path(&path) else {
+        let Ok(entry) = self.task_mgr.get_vault_data_from_path(&path) else {
             error!("Error while collecting tasks from path");
-            return None;
-        };
-
-        let Some(entry) = entries.first() else {
-            error!("No entries found in path: {:?}", path);
             return None;
         };
 

--- a/src/components/explorer_tab/utils.rs
+++ b/src/components/explorer_tab/utils.rs
@@ -111,10 +111,7 @@ impl ExplorerTab<'_> {
         path
     }
     pub(super) fn get_selected_task(&self) -> Option<Task> {
-        let Ok(entries) = self
-            .task_mgr
-            .get_vault_data_from_path(&self.current_path, false)
-        else {
+        let Ok(entries) = self.task_mgr.get_vault_data_from_path(&self.current_path) else {
             error!("Error while collecting tasks from path");
             return None;
         };

--- a/src/components/explorer_tab/utils.rs
+++ b/src/components/explorer_tab/utils.rs
@@ -111,7 +111,10 @@ impl ExplorerTab<'_> {
         path
     }
     pub(super) fn get_selected_task(&self) -> Option<Task> {
-        let Ok(entries) = self.task_mgr.get_vault_data_from_path(&self.current_path) else {
+        let Ok(entries) = self
+            .task_mgr
+            .get_vault_data_from_path_offset(&self.current_path)
+        else {
             error!("Error while collecting tasks from path");
             return None;
         };

--- a/src/core.rs
+++ b/src/core.rs
@@ -161,60 +161,6 @@ impl TaskManager {
             }
         }
     }
-    /// Follows a path and returns every `VaultData` that are on the target layer, discarding every children.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if the path can't be resolved.
-    pub fn get_path_layer_entries(&self, path: &[String]) -> Result<Vec<VaultData>> {
-        Ok(self
-            .get_explorer_entries(path)?
-            .iter()
-            .map(|vd| match vd {
-                VaultData::Directory(name, _) => VaultData::Directory(name.clone(), vec![]),
-                VaultData::Header(level, name, _) => {
-                    VaultData::Header(*level, name.clone(), vec![])
-                }
-                VaultData::Task(t) => {
-                    let mut t = t.clone();
-                    t.subtasks = vec![];
-                    VaultData::Task(t)
-                }
-            })
-            .collect::<Vec<VaultData>>())
-    }
-
-    /// Recursively calls `Task.fix_task_attributes` on every task from the vault.
-    fn rewrite_vault_tasks(config: &TasksConfig, tasks: &VaultData) -> Result<()> {
-        fn explore_tasks_rec(
-            config: &TasksConfig,
-            filename: &mut PathBuf,
-            file_entry: &VaultData,
-        ) -> Result<()> {
-            match file_entry {
-                VaultData::Header(_, _, children) => {
-                    children
-                        .iter()
-                        .try_for_each(|c| explore_tasks_rec(config, filename, c))?;
-                }
-                VaultData::Task(task) => {
-                    task.fix_task_attributes(config, filename)?;
-                    task.subtasks
-                        .iter()
-                        .try_for_each(|t| t.fix_task_attributes(config, filename))?;
-                }
-                VaultData::Directory(dir_name, children) => {
-                    let mut filename = filename.clone();
-                    filename.push(dir_name);
-                    children
-                        .iter()
-                        .try_for_each(|c| explore_tasks_rec(config, &mut filename.clone(), c))?;
-                }
-            }
-            Ok(())
-        }
-        explore_tasks_rec(config, &mut PathBuf::new(), tasks)
-    }
 
     /// Follows the `selected_header_path` to retrieve the correct `VaultData`.
     /// Then returns every `VaultData` objects on the same layer.
@@ -272,17 +218,66 @@ impl TaskManager {
         }
     }
 
-    /// Follows the `selected_header_path` to retrieve the correct `VaultData`.
-    /// Returns a vector of `VaultData` with the items to display in TUI, preserving the recursive nature.
-    /// `task_preview_offset`: add offset to return a task instead of one of its subtasks
+    /// Same as `get_explorer_entries`, but discards any children of the entries.
     ///
     /// # Errors
-    /// Will return an error if
-    /// - vault is empty or the first layer is not a `VaultData::Directory`
-    /// - the path can't be resolved in the vault data
+    ///
+    /// This function will return an error if the path can't be resolved.
+    pub fn get_explorer_entries_without_children(&self, path: &[String]) -> Result<Vec<VaultData>> {
+        Ok(self
+            .get_explorer_entries(path)? // Get the entries at the path
+            .iter() // Discard every children
+            .map(|vd| match vd {
+                VaultData::Directory(name, _) => VaultData::Directory(name.clone(), vec![]),
+                VaultData::Header(level, name, _) => {
+                    VaultData::Header(*level, name.clone(), vec![])
+                }
+                VaultData::Task(t) => {
+                    let mut t = t.clone();
+                    t.subtasks = vec![]; // Discard subtasks
+                    VaultData::Task(t)
+                }
+            })
+            .collect::<Vec<VaultData>>())
+    }
+
+    /// Recursively calls `Task.fix_task_attributes` on every task from the vault.
+    fn rewrite_vault_tasks(config: &TasksConfig, tasks: &VaultData) -> Result<()> {
+        fn explore_tasks_rec(
+            config: &TasksConfig,
+            filename: &mut PathBuf,
+            file_entry: &VaultData,
+        ) -> Result<()> {
+            match file_entry {
+                VaultData::Header(_, _, children) => {
+                    children
+                        .iter()
+                        .try_for_each(|c| explore_tasks_rec(config, filename, c))?;
+                }
+                VaultData::Task(task) => {
+                    task.fix_task_attributes(config, filename)?;
+                    task.subtasks
+                        .iter()
+                        .try_for_each(|t| t.fix_task_attributes(config, filename))?;
+                }
+                VaultData::Directory(dir_name, children) => {
+                    let mut filename = filename.clone();
+                    filename.push(dir_name);
+                    children
+                        .iter()
+                        .try_for_each(|c| explore_tasks_rec(config, &mut filename.clone(), c))?;
+                }
+            }
+            Ok(())
+        }
+        explore_tasks_rec(config, &mut PathBuf::new(), tasks)
+    }
+
+    /// Retrieves the `VaultData` at the given `path`, and returns every entries on the same layer.
+    /// The `task_preview_offset` allows to retrieve the task itself (if it is a task) or its subtasks.
     pub fn get_vault_data_from_path(
         &self,
-        selected_header_path: &[String],
+        path: &[String],
         task_preview_offset: usize,
     ) -> Result<Vec<VaultData>> {
         fn aux(
@@ -291,6 +286,7 @@ impl TaskManager {
             path_index: usize,
             task_preview_offset: usize,
         ) -> Result<Vec<VaultData>> {
+            // Remaining path is empty?
             if path_index == selected_header_path.len() {
                 Ok(vec![file_entry])
             } else {
@@ -298,6 +294,7 @@ impl TaskManager {
                     VaultData::Directory(name, children) | VaultData::Header(_, name, children) => {
                         if name == selected_header_path[path_index] {
                             let mut res = vec![];
+                            // Look for the child that matches the path
                             for child in children {
                                 if let Ok(mut found) = aux(
                                     child,
@@ -306,10 +303,12 @@ impl TaskManager {
                                     task_preview_offset,
                                 ) {
                                     res.append(&mut found);
+                                    // I'm tempted to break here but we might have multiple entries with the same name
                                 }
                             }
                             Ok(res)
                         } else {
+                            // Either it's the first layer and the path is wrong or we recursively called on the wrong entry which is impossible
                             bail!("Couldn't find corresponding entry");
                         }
                     }
@@ -348,7 +347,7 @@ impl TaskManager {
         match filtered_tasks {
             Some(VaultData::Directory(_, entries)) => {
                 for entry in entries {
-                    if let Ok(res) = aux(entry, selected_header_path, 0, task_preview_offset) {
+                    if let Ok(res) = aux(entry, path, 0, task_preview_offset) {
                         return Ok(res);
                     }
                 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -275,7 +275,7 @@ impl TaskManager {
     /// Retrieves the `VaultData` at the given `path`, and returns the entries to display.
     ///
     /// If the path ends with a task, the `task_preview_offset` parameter determines whether the function should return the task itself or its content (subtasks) as with directories and headers.
-    pub fn get_vault_data_from_path_offset(&self, path: &[String]) -> Result<Vec<VaultData>> {
+    pub fn get_vault_data_from_path(&self, path: &[String]) -> Result<Vec<VaultData>> {
         /// Recursively searches for the entry in the vault.
         /// `path_index` is the index of the current path element we are looking for.
         fn aux(
@@ -512,7 +512,7 @@ mod tests {
         };
 
         let path = vec![String::from("Test"), String::from("1"), String::from("2")];
-        let res = task_mgr.get_vault_data_from_path_offset(&path).unwrap();
+        let res = task_mgr.get_vault_data_from_path(&path).unwrap();
         assert_eq!(vec![expected_header], res);
 
         let path = vec![
@@ -521,7 +521,7 @@ mod tests {
             String::from("2"),
             String::from("3"),
         ];
-        let res = task_mgr.get_vault_data_from_path_offset(&path).unwrap();
+        let res = task_mgr.get_vault_data_from_path(&path).unwrap();
         assert_eq!(expected_tasks, res);
     }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -272,12 +272,10 @@ impl TaskManager {
         }
         explore_tasks_rec(config, &mut PathBuf::new(), tasks)
     }
-
     /// Retrieves the `VaultData` at the given `path`, and returns the entries to display.
     ///
-    ///  We want to display it the in the Explorer Preview instead of displaying its content as with headers or directories, so we use an offset to return the task the path points to instead of its subtasks.
-    /// The offset is set to false when we want to retrieve the task for editing for example.
-    pub fn get_vault_data_from_path(
+    /// If the path ends with a task, the `task_preview_offset` parameter determines whether the function should return the task itself or its content (subtasks) as with directories and headers.
+    fn get_vault_data_from_path_offset(
         &self,
         path: &[String],
         task_preview_offset: bool,
@@ -368,6 +366,14 @@ impl TaskManager {
                 bail!("Empty Vault")
             }
         }
+    }
+
+    pub fn get_vault_data_from_path(&self, path: &[String]) -> Result<Vec<VaultData>> {
+        Self::get_vault_data_from_path_offset(self, path, false)
+    }
+    /// Retrieves the `VaultData` at the given `path`, and returns the entries to display.
+    pub fn get_vault_data_from_path_to_preview(&self, path: &[String]) -> Result<Vec<VaultData>> {
+        Self::get_vault_data_from_path_offset(self, path, true)
     }
 
     /// Whether the path resolves to something that can be entered or not.
@@ -497,7 +503,7 @@ mod tests {
         };
 
         let path = vec![String::from("Test"), String::from("1"), String::from("2")];
-        let res = task_mgr.get_vault_data_from_path(&path, false).unwrap();
+        let res = task_mgr.get_vault_data_from_path(&path).unwrap();
         assert_eq!(vec![expected_header], res);
 
         let path = vec![
@@ -506,7 +512,7 @@ mod tests {
             String::from("2"),
             String::from("3"),
         ];
-        let res = task_mgr.get_vault_data_from_path(&path, false).unwrap();
+        let res = task_mgr.get_vault_data_from_path(&path).unwrap();
         assert_eq!(expected_tasks, res);
     }
 }

--- a/src/core/parser/parser_file_entry.rs
+++ b/src/core/parser/parser_file_entry.rs
@@ -541,7 +541,7 @@ impl ParserFileEntry<'_> {
     }
 
     /// Removes any empty headers from a `FileEntry`
-    fn clean_file_entry(file_entry: &mut VaultData) -> Option<&VaultData> {
+    fn clean_file_entry(file_entry: &mut VaultData) -> Option<VaultData> {
         match file_entry {
             VaultData::Header(_, _, children) | VaultData::Directory(_, children) => {
                 let mut actual_children = vec![];
@@ -553,13 +553,12 @@ impl ParserFileEntry<'_> {
                 }
                 *children = actual_children;
                 if children.is_empty() {
-                    None
-                } else {
-                    Some(file_entry)
+                    return None;
                 }
             }
-            VaultData::Task(_) => Some(file_entry),
+            VaultData::Task(_) => (),
         }
+        Some(file_entry.to_owned())
     }
 
     pub fn parse_file(&mut self, filename: &str, input: &&str) -> Option<VaultData> {
@@ -581,12 +580,7 @@ impl ParserFileEntry<'_> {
             file_tags.iter().for_each(|t| add_global_tag(&mut res, t));
         }
 
-        // Filename is changed from Header to Directory variant at the end
-        if let Some(VaultData::Header(_, name, children)) = Self::clean_file_entry(&mut res) {
-            Some(VaultData::Directory(name.clone(), children.clone()))
-        } else {
-            None
-        }
+        Self::clean_file_entry(&mut res)
     }
 }
 


### PR DESCRIPTION
Wanted to do some refactoring of `core.rs` but turned out it was easier to rewrite this logic.

This gets rid of the `task_preview_offset` parameter in `TaskManager::get_vault_data_from_path()` and makes the first header of a file an actual `VaultData::Header` instead of a `VaultData::Directory`. 