### PR TITLE
Feat: Add an invert search terms flag

### DIFF
--- a/src/core/filter.rs
+++ b/src/core/filter.rs
@@ -11,13 +11,15 @@ use super::{
 pub struct Filter {
     pub task: Task,
     inverted: bool,
+    /// Separate state in case we're not filtering by state
+    /// Since tasks require a state to be valid, we'll add a default one but use this one
     state: Option<State>,
 }
 
-/// Parses a [`Task`] from an input `&str`. Returns the `Task` and whether the input specify a task state (- [X] or - [ ]) or not.
+/// Parses a [`Task`] from an input `&str`. Returns a [`Filter`] object.
 #[must_use]
 pub fn parse_search_input(input: &str, config: &TasksConfig) -> Filter {
-    // Are searching for a specific state ?
+    // Invert results ? If so, remove the `!` prefix
     let inverted = input.starts_with('!');
     let input = input.strip_prefix('!').unwrap_or(input);
 


### PR DESCRIPTION
Adds a `!` flag to invert search results in Explorer and Filter tabs as mentioned in #84
Because the search string is parsed as a regular task, I can't add an invert flag for specific tokens, instead it inverts the full search string.




# Examples
![image](https://github.com/user-attachments/assets/3907b6b4-4514-4bf3-a41f-dbdcda2496d1)
![image](https://github.com/user-attachments/assets/fa5b1ed5-5ba6-405c-828a-f2b64a8ce776)
![image](https://github.com/user-attachments/assets/d60f2474-7fc1-411c-ae7b-c78a008a7b4e)
